### PR TITLE
Add missing sign-up page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,9 +4,9 @@ import {
   SignedIn,
   SignedOut,
   SignInButton,
-  SignUpButton,
   UserButton,
 } from "@clerk/nextjs";
+import Link from "next/link";
 import "./globals.css";
 
 export default function RootLayout({
@@ -23,7 +23,9 @@ export default function RootLayout({
           <header style={{ padding: 20, borderBottom: "1px solid #eee" }}>
             <SignedOut>
               <SignInButton />{" "}
-              <SignUpButton />
+              <Link href="/sign-up" style={{ marginLeft: 8 }}>
+                Sign Up
+              </Link>
             </SignedOut>
             <SignedIn>
               <UserButton />

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { SignUp } from "@clerk/nextjs";
+
+export default function SignUpPage() {
+  return (
+    <div style={{ maxWidth: 400, margin: "2rem auto", padding: "1rem" }}>
+      <h1>Create an account</h1>
+      <SignUp routing="path" path="/sign-up" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated Clerk sign-up page
- link to the sign-up page from the layout header

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ce3ec429883338e1d68c9f43cde9f